### PR TITLE
Fix chart.js package name capitalization

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "tests"
   ],
   "dependencies": {
-    "Chart.js": ">= 2.1.0"
+    "chart.js": ">= 2.1.0"
   }
 }


### PR DESCRIPTION
Requiring Chart.js with a capital C causes Bower installation conflicts if other dependencies also require chart.js with the correct lower case name.