### PR TITLE
 Adds option "showActualPercentages" to skip 100% logics

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ new Chart(ctx, {
 
       // draw label even it's overlap, default is false
       overlap: true,
+	  
+	  // show the real calculated percentages from the values and don't apply the additional logic to fit the percentages to 100 in total, default is false
+	  showActualPercentages: true,
 
       // set images when `render` is 'image'
       images: [

--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ new Chart(ctx, {
 
       // draw label even it's overlap, default is false
       overlap: true,
+      
+      // show the real calculated percentages from the values and don't apply the additional logic to fit the percentages to 100 in total, default is false
+      showActualPercentages: true,
 
       // set images when `render` is 'image'
       images: [

--- a/README.md
+++ b/README.md
@@ -60,9 +60,6 @@ new Chart(ctx, {
 
       // draw label even it's overlap, default is false
       overlap: true,
-	  
-	  // show the real calculated percentages from the values and don't apply the additional logic to fit the percentages to 100 in total, default is false
-	  showActualPercentages: true,
 
       // set images when `render` is 'image'
       images: [

--- a/src/Chart.PieceLabel.js
+++ b/src/Chart.PieceLabel.js
@@ -63,15 +63,13 @@
         default:
           var percentage = view.circumference / this.options.circumference * 100;
           percentage = parseFloat(percentage.toFixed(this.precision));
-		  if(!this.options.showActualPercentages){
-			totalPercentage += percentage;
-			if (totalPercentage > 100) {
-			  percentage -= totalPercentage - 100;
-			  // After adjusting the percentage, need to trim the numbers after decimal points again, otherwise it may not show
-			  // on chart due to very long number after decimal point.
-			  percentage = parseFloat(percentage.toFixed(this.precision));
-			}
-		  }
+          totalPercentage += percentage;
+          if (totalPercentage > 100) {
+            percentage -= totalPercentage - 100;
+            // After adjusting the percentage, need to trim the numbers after decimal points again, otherwise it may not show
+            // on chart due to very long number after decimal point.
+            percentage = parseFloat(percentage.toFixed(this.precision));
+          }
           text = percentage + '%';
           break;
       }
@@ -184,7 +182,6 @@
       this.showZero = pieceLabel.showZero;
       this.overlap = pieceLabel.overlap;
       this.images = pieceLabel.images || [];
-	  this.showActualPercentages = pieceLabel.images || false;
       return true;
     } else {
       return false;

--- a/src/Chart.PieceLabel.js
+++ b/src/Chart.PieceLabel.js
@@ -63,12 +63,14 @@
         default:
           var percentage = view.circumference / this.options.circumference * 100;
           percentage = parseFloat(percentage.toFixed(this.precision));
-          totalPercentage += percentage;
-          if (totalPercentage > 100) {
-            percentage -= totalPercentage - 100;
-            // After adjusting the percentage, need to trim the numbers after decimal points again, otherwise it may not show
-            // on chart due to very long number after decimal point.
-            percentage = parseFloat(percentage.toFixed(this.precision));
+          if(!this.options.showActualPercentages){
+            totalPercentage += percentage;
+            if (totalPercentage > 100) {
+              percentage -= totalPercentage - 100;
+              // After adjusting the percentage, need to trim the numbers after decimal points again, otherwise it may not show
+              // on chart due to very long number after decimal point.
+              percentage = parseFloat(percentage.toFixed(this.precision));
+            }
           }
           text = percentage + '%';
           break;
@@ -182,6 +184,7 @@
       this.showZero = pieceLabel.showZero;
       this.overlap = pieceLabel.overlap;
       this.images = pieceLabel.images || [];
+      this.showActualPercentages = pieceLabel.images || false;
       return true;
     } else {
       return false;

--- a/src/Chart.PieceLabel.js
+++ b/src/Chart.PieceLabel.js
@@ -63,13 +63,15 @@
         default:
           var percentage = view.circumference / this.options.circumference * 100;
           percentage = parseFloat(percentage.toFixed(this.precision));
-          totalPercentage += percentage;
-          if (totalPercentage > 100) {
-            percentage -= totalPercentage - 100;
-            // After adjusting the percentage, need to trim the numbers after decimal points again, otherwise it may not show
-            // on chart due to very long number after decimal point.
-            percentage = parseFloat(percentage.toFixed(this.precision));
-          }
+		  if(!this.options.showActualPercentages){
+			totalPercentage += percentage;
+			if (totalPercentage > 100) {
+			  percentage -= totalPercentage - 100;
+			  // After adjusting the percentage, need to trim the numbers after decimal points again, otherwise it may not show
+			  // on chart due to very long number after decimal point.
+			  percentage = parseFloat(percentage.toFixed(this.precision));
+			}
+		  }
           text = percentage + '%';
           break;
       }
@@ -182,6 +184,7 @@
       this.showZero = pieceLabel.showZero;
       this.overlap = pieceLabel.overlap;
       this.images = pieceLabel.images || [];
+	  this.showActualPercentages = pieceLabel.images || false;
       return true;
     } else {
       return false;

--- a/src/Chart.PieceLabel.js
+++ b/src/Chart.PieceLabel.js
@@ -184,7 +184,7 @@
       this.showZero = pieceLabel.showZero;
       this.overlap = pieceLabel.overlap;
       this.images = pieceLabel.images || [];
-      this.showActualPercentages = pieceLabel.images || false;
+      this.showActualPercentages = pieceLabel.showActualPercentages || false;
       return true;
     } else {
       return false;


### PR DESCRIPTION
This pull requests adds a new configuration value. The value is called "showActualPercentages" and it skips the 100% in total logics, when set to true. The value is set to false by default to preserve current behaviour.

~ Sorry for 3 Commits. needed to revert to keep the spaces instead of tabs (stupid editor)