### PR TITLE
adjust offset for outside labels so they don't overlap the chart

### DIFF
--- a/src/Chart.PieceLabel.js
+++ b/src/Chart.PieceLabel.js
@@ -109,6 +109,7 @@
           y: view.y + (Math.sin(centreAngle) * rangeFromCentre)
         };
         if (this.position === 'outside') {
+          offset += (this.measureText(text).width / 2);
           if (position.x < view.x) {
             position.x -= offset;
           } else {


### PR DESCRIPTION
When using 'outside' labels, long label text will overlap the chart. This change adjusts the offset for outside labels so they don't overlap.