### PR TITLE
Fixed text.split is not a function

### DIFF
--- a/src/Chart.PieceLabel.js
+++ b/src/Chart.PieceLabel.js
@@ -91,6 +91,8 @@
 
         if (typeof text === 'object') {
           text = this.loadImage(text);
+        } else {
+          text = text.toString();
         }
       }
       if (!text) {


### PR DESCRIPTION
Fixed text.split is not a function when render custom function response is not a string