### PR TITLE
Add datasetIndex and chart instances to render and fontColor function…

### DIFF
--- a/src/chartjs-plugin-labels.js
+++ b/src/chartjs-plugin-labels.js
@@ -197,7 +197,9 @@
         value: dataset.data[index],
         percentage: this.getPercentage(dataset, element, index),
         dataset: dataset,
-        index: index
+        index: index,
+        datasetIndex: element._datasetIndex,
+		    chart: this.chart
       });
     } else {
       switch (this.options.render) {
@@ -233,7 +235,9 @@
         percentage: this.getPercentage(dataset, element, index),
         backgroundColor: dataset.backgroundColor[index],
         dataset: dataset,
-        index: index
+        index: index,
+        datasetIndex: element._datasetIndex,
+		    chart: this.chart
       });
     } else if (typeof fontColor !== 'string') {
       fontColor = fontColor[index] || this.chart.config.options.defaultFontColor;


### PR DESCRIPTION
… object

To implement a customization on rendering and coloring you could need of information based on other elements of chart (not only dataset item). Furthermore 'index' represent the value inside the dataset but not the dataset index. Therefore I suggest to add 'datasetIndex' and 'chart' into the object to pass as argument to callbacks.