### PR TITLE
Fix bad option name in drawable

### DIFF
--- a/src/chartjs-plugin-labels.js
+++ b/src/chartjs-plugin-labels.js
@@ -357,7 +357,7 @@
         right = renderInfo.x + mertrics.width / 2,
         top = renderInfo.y - mertrics.height / 2,
         bottom = renderInfo.y + mertrics.height / 2;
-      if (this.options.renderInfo === 'outside') {
+      if (this.options.position === 'outside') {
         return this.outsideInRange(left, right, top, bottom);
       } else {
         return element.inRange(left, top) && element.inRange(left, bottom) &&


### PR DESCRIPTION
There is a typo in the drawable function, that prevent the overlaping when position is outside.

Probably fixing #91 