### PR TITLE
Fix: parcentage value calculation is fixed so the value is rounded.

### DIFF
--- a/src/chartjs-plugin-labels.js
+++ b/src/chartjs-plugin-labels.js
@@ -267,9 +267,6 @@
     }
     percentage = parseFloat(Math.round(percentage * Math.pow(10, this.options.precision)) / Math.pow(10, this.options.precision));
 
-
-
-
     if (!this.options.showActualPercentages) {
       if (this.chart.config.type === 'bar') {
         this.totalPercentage = this.barTotalPercentage[index] || 0;

--- a/src/chartjs-plugin-labels.js
+++ b/src/chartjs-plugin-labels.js
@@ -265,7 +265,11 @@
     } else {
       percentage = element._view.circumference / this.chart.config.options.circumference * 100;
     }
-    percentage = parseFloat(percentage.toFixed(this.options.precision));
+    percentage = parseFloat(Math.round(percentage * Math.pow(10, this.options.precision)) / Math.pow(10, this.options.precision));
+
+
+
+
     if (!this.options.showActualPercentages) {
       if (this.chart.config.type === 'bar') {
         this.totalPercentage = this.barTotalPercentage[index] || 0;
@@ -273,7 +277,7 @@
       this.totalPercentage += percentage;
       if (this.totalPercentage > 100) {
         percentage -= this.totalPercentage - 100;
-        percentage = parseFloat(percentage.toFixed(this.options.precision));
+        percentage = parseFloat(Math.round(percentage * Math.pow(10, this.options.precision)) / Math.pow(10, this.options.precision));
       }
       if (this.chart.config.type === 'bar') {
         this.barTotalPercentage[index] = this.totalPercentage


### PR DESCRIPTION
The percentage value was calculated by .toFixed method which just cut the decimal values like Math.floor. I updated the logic for the percentage values so it's properly rounded at the specified decimal position by the precision option.

ie:
When the value is 56.5556 and the precision is 1:
original version: 56.5%
updated version: 56.6%

I'd appreciate if you could merge this fix.
Cheers:)