### PR TITLE
fix label generation if canvas generated on scroll

### DIFF
--- a/src/chartjs-plugin-labels.js
+++ b/src/chartjs-plugin-labels.js
@@ -81,9 +81,10 @@
     this.totalPercentage = 0;
     this.total = null;
     var arg = this.args[index];
-    arg.meta.data.forEach(function (element, index) {
-      this.renderToElement(dataset, arg, element, index);
-    }.bind(this));
+    if(arg)
+      arg.meta.data.forEach(function (element, index) {
+        this.renderToElement(dataset, arg, element, index);
+      }.bind(this));
   };
 
   Label.prototype.renderToElement = function (dataset, arg, element, index) {


### PR DESCRIPTION
When using another plugin ([chartjs-plugin-deferred](https://github.com/chartjs/chartjs-plugin-deferred)) the script was failing with : 
> chartjs-plugin-labels.js:84 Uncaught TypeError: Cannot read property 'meta' of undefined
    at Label../node_modules/chartjs-plugin-labels/src/chartjs-plugin-labels.js.Label.renderToDataset (chartjs-plugin-labels.js:84)
    at Array.forEach (<anonymous>)
    at Label../node_modules/chartjs-plugin-labels/src/chartjs-plugin-labels.js.Label.render (chartjs-plugin-labels.js:77)
    at chartjs-plugin-labels.js:486
    at Array.forEach (<anonymous>)
    at Object.afterDatasetsDraw (chartjs-plugin-labels.js:485)
    at Object.notify (Chart.js:7173)
    at Chart.drawDatasets (Chart.js:8948)
    at Chart.draw (Chart.js:8908)
    at Chart.render (Chart.js:8866)
    at Object.callback (Chart.js:1778)
    at Object.advance (Chart.js:2952)
    at Object.startDigest (Chart.js:2925)
    at Chart.js:2914

It is basically because the canvas is rendered but chart not drawned yet. This modification testing arg for null/undefined/false fixes the problem.