### PR TITLE
Fix Stacked Bar chart label overlapping

### DIFF
--- a/src/chartjs-plugin-labels.js
+++ b/src/chartjs-plugin-labels.js
@@ -212,7 +212,7 @@
           break;
         case 'percentage':
         default:
-          label = this.getPercentage(dataset, element, index) + '%';
+          label = this.getPercentage(dataset, element, index) ? this.getPercentage(dataset, element, index) + '%' : '';
           break;
       }
     }


### PR DESCRIPTION
When using Stacked Bar Chart the labels (100% and 0%) are overlapping.