### PR TITLE
add none render type

### DIFF
--- a/src/chartjs-plugin-labels.js
+++ b/src/chartjs-plugin-labels.js
@@ -201,6 +201,9 @@
       });
     } else {
       switch (this.options.render) {
+        case 'none':
+          label = '';
+          break;
         case 'value':
           label = dataset.data[index];
           break;


### PR DESCRIPTION
Thanks for the work done,

I've done a simple pull request for a 'none' render type. I can do with an function but in my case, it was impossible as the configuration is generated with a json parser which doesn't manager JS function, only valid Json value like string or integer.